### PR TITLE
Fix Cannot read property 'body' of undefined #1

### DIFF
--- a/polymer-svg-template.js
+++ b/polymer-svg-template.js
@@ -33,7 +33,7 @@
     }
 
     // owner document of this import module
-    var doc = window.currentImport;
+    var doc = document.currentScript.ownerDocument;
     var ns = doc.body.namespaceURI;
 
     var template = Polymer.DomModule.import(name, 'template');


### PR DESCRIPTION
Fix error in Chrome and Safari.
Still not working in Firefox but this is another issue. 
Couldn't test what's happening in IE and Edge. 